### PR TITLE
refactor: remove unused imports

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Bot, Send, Sparkles, X, Brain, Code2, Database, GitBranch, Search } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { Bot, Send, Sparkles, X, Brain } from 'lucide-react';
 
 interface Message {
   id: string;

--- a/src/components/DashboardsSection.tsx
+++ b/src/components/DashboardsSection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Plus, Search, BarChart2, PieChart, LineChart, Share2, Calendar, Filter, Download, RefreshCw, Clock } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, BarChart2, PieChart, LineChart, Calendar, Filter, Download, RefreshCw, Clock } from 'lucide-react';
 import { AnalyticsDashboard } from './dashboards/AnalyticsDashboard';
 import { MetricCard } from './dashboards/MetricCard';
 

--- a/src/components/DataSection.tsx
+++ b/src/components/DataSection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Plus, Search, Filter, Upload, Database, Link } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Search } from 'lucide-react';
 import { DataCatalog } from './DataCatalog';
 import { DatabaseArchitecture } from './data/DatabaseArchitecture';
 import { DataFlowVisualizer } from './data/DataFlowVisualizer';

--- a/src/components/workspace/AIAnalysisSection.tsx
+++ b/src/components/workspace/AIAnalysisSection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Brain, Search, BarChart2, Table, FileText, ArrowRight } from 'lucide-react';
+import { useState } from 'react';
+import { Brain, BarChart2, Table, FileText } from 'lucide-react';
 
 export function AIAnalysisSection() {
   const [prompt, setPrompt] = useState('');

--- a/src/components/workspace/QuerySection.tsx
+++ b/src/components/workspace/QuerySection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Play, Save, Download, Database, Table, ChevronRight, Code2, Brain } from 'lucide-react';
+import { useState } from 'react';
+import { Play, Save, Download, Database, ChevronRight, Code2, Brain } from 'lucide-react';
 
 export function QuerySection() {
   const [query, setQuery] = useState('');


### PR DESCRIPTION
## Summary
- prune unused imports in AI assistant and dashboard components
- streamline data section by removing unused icons
- drop unused lucide icons in workspace utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: see output)*

------
https://chatgpt.com/codex/tasks/task_e_688e33c780ec83229fc57f1138e9cdfb