### PR TITLE
refactor: replace explicit any with specific types

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -13,7 +13,7 @@ interface Message {
 interface AIAssistantProps {
   context?: {
     currentView?: string;
-    selectedData?: any;
+    selectedData?: unknown;
     activeProject?: string;
   };
 }

--- a/src/components/DataSection.tsx
+++ b/src/components/DataSection.tsx
@@ -4,8 +4,8 @@ import { DataCatalog } from './DataCatalog';
 import { DatabaseArchitecture } from './data/DatabaseArchitecture';
 import { DataFlowVisualizer } from './data/DataFlowVisualizer';
 import { UploadDataModal } from './data/UploadDataModal';
-import { ConnectDatabaseModal } from './data/ConnectDatabaseModal';
-import { APIIntegrationModal } from './data/APIIntegrationModal';
+import { ConnectDatabaseModal, DatabaseConfig } from './data/ConnectDatabaseModal';
+import { APIIntegrationModal, APIConfig } from './data/APIIntegrationModal';
 
 export function DataSection() {
   const [view, setView] = useState('architecture');
@@ -17,11 +17,11 @@ export function DataSection() {
     console.log('Uploading file:', file.name);
   };
 
-  const handleDatabaseConnect = (config: any) => {
+  const handleDatabaseConnect = (config: DatabaseConfig) => {
     console.log('Connecting to database:', config);
   };
 
-  const handleAPIConnect = (config: any) => {
+  const handleAPIConnect = (config: APIConfig) => {
     console.log('Connecting to API:', config);
   };
 

--- a/src/components/ModelsSection.tsx
+++ b/src/components/ModelsSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Plus, Search, Brain, Sparkles, GitBranch, History, Play, Settings, Database, ChevronRight, BarChart2, AlertCircle, Clock } from 'lucide-react';
-import { NewModelModal } from './models/NewModelModal';
+import { NewModelModal, NewModelData } from './models/NewModelModal';
 import { ModelTrainingView } from './models/ModelTrainingView';
 import { AutoMLView } from './models/AutoMLView';
 import { ModelDeploymentView } from './models/ModelDeploymentView';
@@ -64,7 +64,7 @@ export function ModelsSection() {
     }
   ];
 
-  const handleCreateModel = (modelData: any) => {
+  const handleCreateModel = (modelData: NewModelData) => {
     console.log('Creating new model:', modelData);
     setIsNewModelModalOpen(false);
   };

--- a/src/components/NewNotebookModal.tsx
+++ b/src/components/NewNotebookModal.tsx
@@ -1,10 +1,17 @@
 import React, { useState } from 'react';
 import { X, FileCode, Wand2, GitBranch, Book, Brain } from 'lucide-react';
 
+export interface NotebookData {
+  name: string;
+  description: string;
+  template: string;
+  created: Date;
+}
+
 interface NewNotebookModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreate: (notebook: any) => void;
+  onCreate: (notebook: NotebookData) => void;
 }
 
 export function NewNotebookModal({ isOpen, onClose, onCreate }: NewNotebookModalProps) {

--- a/src/components/NewResourceModal.tsx
+++ b/src/components/NewResourceModal.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import { X, FileCode, BarChart2, GitBranch, Database, Terminal, Brain, Sparkles } from 'lucide-react';
 
+interface ResourceData {
+  type: string;
+}
+
 interface NewResourceModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreateResource: (resource: any) => void;
+  onCreateResource: (resource: ResourceData) => void;
 }
 
 export function NewResourceModal({ isOpen, onClose, onCreateResource }: NewResourceModalProps) {

--- a/src/components/NotebookEditor.tsx
+++ b/src/components/NotebookEditor.tsx
@@ -2,12 +2,13 @@ import React, { useState } from 'react';
 import { Play, Save, Download, Plus, Brain, MessageSquare, Code2, Database, Table, ChevronRight } from 'lucide-react';
 import { AIAssistant } from './AIAssistant';
 import { CodeCell } from './notebook/CodeCell';
+import { ExecutionResult } from './notebook/CodeInterpreter';
 
 interface Cell {
   id: string;
   type: 'markdown' | 'python' | 'sql' | 'visualization';
   content: string;
-  output?: any;
+  output?: ExecutionResult;
   metadata?: {
     database?: string;
     table?: string;

--- a/src/components/NotebooksSection.tsx
+++ b/src/components/NotebooksSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Plus, Search, FileCode, Play, Book, Code2, Sparkles, Brain, GitBranch, Share2, History } from 'lucide-react';
-import { NewNotebookModal } from './NewNotebookModal';
+import { NewNotebookModal, NotebookData } from './NewNotebookModal';
 import { NotebookEditor } from './NotebookEditor';
 
 interface Notebook {
@@ -52,7 +52,7 @@ export function NotebooksSection() {
     },
   ]);
 
-  const handleCreateNotebook = (notebookData: any) => {
+  const handleCreateNotebook = (notebookData: NotebookData) => {
     const newNotebook: Notebook = {
       id: notebooks.length + 1,
       name: notebookData.name,

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -3,7 +3,7 @@ import { Play, Save, Download, Database, Table, ChevronRight, Code2 } from 'luci
 
 interface QueryResult {
   columns: string[];
-  rows: any[];
+  rows: Record<string, unknown>[];
 }
 
 export function QueryEditor() {
@@ -113,7 +113,7 @@ export function QueryEditor() {
                           key={column}
                           className="px-6 py-4 whitespace-nowrap text-sm text-slate-300"
                         >
-                          {row[column]}
+                          {String(row[column])}
                         </td>
                       ))}
                     </tr>

--- a/src/components/SignUpModal.tsx
+++ b/src/components/SignUpModal.tsx
@@ -2,10 +2,14 @@ import React, { useState } from 'react';
 import { Github, Linkedin, Loader2, Mail, X } from 'lucide-react';
 import { useAuth0 } from '@auth0/auth0-react';
 
+interface SignUpData {
+  provider: string;
+}
+
 interface SignUpModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSignUp: (data: any) => void;
+  onSignUp: (data: SignUpData) => void;
 }
 
 export function SignUpModal({ isOpen, onClose, onSignUp }: SignUpModalProps) {

--- a/src/components/data/APIIntegrationModal.tsx
+++ b/src/components/data/APIIntegrationModal.tsx
@@ -1,14 +1,22 @@
 import React, { useState } from 'react';
 import { X, Link, Key, Globe, Clock } from 'lucide-react';
 
+export interface APIConfig {
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  authType: string;
+  refreshInterval: string;
+}
+
 interface APIIntegrationModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConnect: (config: any) => void;
+  onConnect: (config: APIConfig) => void;
 }
 
 export function APIIntegrationModal({ isOpen, onClose, onConnect }: APIIntegrationModalProps) {
-  const [config, setConfig] = useState({
+  const [config, setConfig] = useState<APIConfig>({
     name: '',
     baseUrl: '',
     apiKey: '',

--- a/src/components/data/ConnectDatabaseModal.tsx
+++ b/src/components/data/ConnectDatabaseModal.tsx
@@ -1,15 +1,28 @@
 import React, { useState } from 'react';
 import { X, Database, Key, Server, Lock } from 'lucide-react';
 
+interface DatabaseConfigBase {
+  host: string;
+  port: string;
+  database: string;
+  username: string;
+  password: string;
+  ssl: boolean;
+}
+
+export interface DatabaseConfig extends DatabaseConfigBase {
+  type: string;
+}
+
 interface ConnectDatabaseModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onConnect: (config: any) => void;
+  onConnect: (config: DatabaseConfig) => void;
 }
 
 export function ConnectDatabaseModal({ isOpen, onClose, onConnect }: ConnectDatabaseModalProps) {
   const [dbType, setDbType] = useState('postgresql');
-  const [config, setConfig] = useState({
+  const [config, setConfig] = useState<DatabaseConfigBase>({
     host: '',
     port: '',
     database: '',
@@ -22,7 +35,8 @@ export function ConnectDatabaseModal({ isOpen, onClose, onConnect }: ConnectData
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onConnect({ ...config, type: dbType });
+    const fullConfig: DatabaseConfig = { ...config, type: dbType };
+    onConnect(fullConfig);
     onClose();
   };
 

--- a/src/components/data/DatabaseArchitecture.tsx
+++ b/src/components/data/DatabaseArchitecture.tsx
@@ -154,7 +154,7 @@ export function DatabaseArchitecture() {
           <div className="flex items-center space-x-4">
             <select
               value={view}
-              onChange={(e) => setView(e.target.value as any)}
+              onChange={(e) => setView(e.target.value as 'er' | 'flow' | '3d')}
               className="bg-slate-700 text-white px-3 py-1.5 rounded-lg"
             >
               <option value="er">ER Diagram</option>

--- a/src/components/models/NewModelModal.tsx
+++ b/src/components/models/NewModelModal.tsx
@@ -1,14 +1,22 @@
 import React, { useState } from 'react';
 import { X, Brain, Database, GitBranch, Sparkles } from 'lucide-react';
 
+export interface NewModelData {
+  name: string;
+  type: 'classification' | 'regression' | 'recommendation';
+  description: string;
+  dataset: string;
+  target: string;
+}
+
 interface NewModelModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreate: (modelData: any) => void;
+  onCreate: (modelData: NewModelData) => void;
 }
 
 export function NewModelModal({ isOpen, onClose, onCreate }: NewModelModalProps) {
-  const [modelData, setModelData] = useState({
+  const [modelData, setModelData] = useState<NewModelData>({
     name: '',
     type: 'classification',
     description: '',

--- a/src/components/notebook/CodeCell.tsx
+++ b/src/components/notebook/CodeCell.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Code2 } from 'lucide-react';
-import { CodeInterpreter } from './CodeInterpreter';
+import { CodeInterpreter, ExecutionResult } from './CodeInterpreter';
 
 interface CodeCellProps {
   id: string;
@@ -11,14 +11,14 @@ interface CodeCellProps {
 
 export function CodeCell({ id, language, initialCode = '', onChange }: CodeCellProps) {
   const [code, setCode] = useState(initialCode);
-  const [output, setOutput] = useState<any>(null);
+  const [output, setOutput] = useState<ExecutionResult | null>(null);
 
   const handleCodeChange = (newCode: string) => {
     setCode(newCode);
     onChange?.(newCode);
   };
 
-  const handleResult = (result: any) => {
+  const handleResult = (result: ExecutionResult) => {
     setOutput(result);
   };
 
@@ -68,14 +68,11 @@ export function CodeCell({ id, language, initialCode = '', onChange }: CodeCellP
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-700">
-                  {output.content.map((row: any, i: number) => (
+                  {output.content.map((row: Record<string, unknown>, i: number) => (
                     <tr key={i}>
-                      {Object.values(row).map((value: any, j: number) => (
-                        <td
-                          key={j}
-                          className="px-4 py-2 text-sm text-slate-300"
-                        >
-                          {value}
+                      {Object.values(row).map((value: unknown, j: number) => (
+                        <td key={j} className="px-4 py-2 text-sm text-slate-300">
+                          {String(value)}
                         </td>
                       ))}
                     </tr>

--- a/src/components/notebook/CodeInterpreter.tsx
+++ b/src/components/notebook/CodeInterpreter.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import { Play, Loader2, XCircle } from 'lucide-react';
 
+export type ExecutionResult =
+  | { type: 'output'; content: string }
+  | { type: 'table'; content: Record<string, unknown>[] };
+
 interface CodeInterpreterProps {
   code: string;
   language: 'python' | 'sql';
-  onResult: (result: any) => void;
+  onResult: (result: ExecutionResult) => void;
 }
 
 export function CodeInterpreter({ code, language, onResult }: CodeInterpreterProps) {
@@ -27,7 +31,7 @@ export function CodeInterpreter({ code, language, onResult }: CodeInterpreterPro
     }
   };
 
-  const simulateExecution = async (code: string, lang: string): Promise<any> => {
+  const simulateExecution = async (code: string, lang: string): Promise<ExecutionResult> => {
     await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (lang === 'python') {

--- a/src/components/pipelines/NodeConfigModal.tsx
+++ b/src/components/pipelines/NodeConfigModal.tsx
@@ -1,22 +1,16 @@
 import React, { useState } from 'react';
 import { X, Database, Code2, GitBranch } from 'lucide-react';
-
-interface Node {
-  id: string;
-  type: 'source' | 'transform' | 'destination';
-  name: string;
-  config: any;
-}
+import { PipelineNodeData, NodeConfig } from '../../types/pipeline';
 
 interface NodeConfigModalProps {
   isOpen: boolean;
   onClose: () => void;
-  node: Node;
-  onSave: (config: any) => void;
+  node: PipelineNodeData;
+  onSave: (config: NodeConfig) => void;
 }
 
 export function NodeConfigModal({ isOpen, onClose, node, onSave }: NodeConfigModalProps) {
-  const [config, setConfig] = useState(node.config);
+  const [config, setConfig] = useState<NodeConfig>(node.config);
   const [name, setName] = useState(node.name);
 
   if (!isOpen) return null;

--- a/src/components/pipelines/PipelineBuilder.tsx
+++ b/src/components/pipelines/PipelineBuilder.tsx
@@ -2,29 +2,17 @@ import React, { useState } from 'react';
 import { Plus, Database, Code2, GitBranch, Settings, Play, Save, Clock, ArrowRight } from 'lucide-react';
 import { PipelineNode } from './PipelineNode';
 import { NodeConfigModal } from './NodeConfigModal';
-
-interface Node {
-  id: string;
-  type: 'source' | 'transform' | 'destination';
-  name: string;
-  config: any;
-  position: { x: number; y: number };
-}
-
-interface Connection {
-  from: string;
-  to: string;
-}
+import { PipelineNodeData, Connection, NodeConfig } from '../../types/pipeline';
 
 export function PipelineBuilder() {
-  const [nodes, setNodes] = useState<Node[]>([]);
+  const [nodes, setNodes] = useState<PipelineNodeData[]>([]);
   const [connections, setConnections] = useState<Connection[]>([]);
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const [selectedNode, setSelectedNode] = useState<PipelineNodeData | null>(null);
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [draggedPosition, setDraggedPosition] = useState({ x: 0, y: 0 });
 
-  const handleAddNode = (type: Node['type']) => {
-    const newNode: Node = {
+  const handleAddNode = (type: PipelineNodeData['type']) => {
+    const newNode: PipelineNodeData = {
       id: Date.now().toString(),
       type,
       name: `New ${type} node`,
@@ -35,7 +23,7 @@ export function PipelineBuilder() {
   };
 
   const handleNodeDrag = (nodeId: string, position: { x: number; y: number }) => {
-    setNodes(nodes.map(node => 
+    setNodes(nodes.map(node =>
       node.id === nodeId ? { ...node, position } : node
     ));
   };
@@ -46,7 +34,7 @@ export function PipelineBuilder() {
     }
   };
 
-  const handleNodeConfigure = (node: Node) => {
+  const handleNodeConfigure = (node: PipelineNodeData) => {
     setSelectedNode(node);
     setIsConfigModalOpen(true);
   };
@@ -161,9 +149,9 @@ export function PipelineBuilder() {
           isOpen={isConfigModalOpen}
           onClose={() => setIsConfigModalOpen(false)}
           node={selectedNode}
-          onSave={(config) => {
+          onSave={(config: NodeConfig) => {
             setNodes(nodes.map(n =>
-              n.id === selectedNode.id ? { ...n, config } : n
+              n.id === selectedNode.id ? { ...n, name: config.name ?? n.name, config } : n
             ));
             setIsConfigModalOpen(false);
           }}

--- a/src/components/team/board/BoardFilter.tsx
+++ b/src/components/team/board/BoardFilter.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Search, Filter, SortAsc, User } from 'lucide-react';
 
+type FilterOptions = Record<string, unknown>;
+
 interface BoardFilterProps {
   onSearch: (query: string) => void;
-  onFilterChange: (filters: any) => void;
+  onFilterChange: (filters: FilterOptions) => void;
 }
 
 export function BoardFilter({ onSearch, onFilterChange }: BoardFilterProps) {

--- a/src/components/team/board/BoardView.tsx
+++ b/src/components/team/board/BoardView.tsx
@@ -141,7 +141,7 @@ export function BoardView({ boardId, boardType }: BoardViewProps) {
     setSearchQuery(query.toLowerCase());
   };
 
-  const handleFilterChange = (filters: any) => {
+  const handleFilterChange = (filters: Record<string, unknown>) => {
     // Implement filter logic
   };
 

--- a/src/components/team/board/NewCardModal.tsx
+++ b/src/components/team/board/NewCardModal.tsx
@@ -1,19 +1,28 @@
 import React, { useState } from 'react';
 import { X, Plus } from 'lucide-react';
 
+interface CardInput {
+  type: 'story' | 'task' | 'bug' | 'epic';
+  title: string;
+  description: string;
+  priority: 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+  labels: string[];
+  estimate: number;
+}
+
 interface NewCardModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreate: (card: any) => void;
+  onCreate: (card: CardInput) => void;
 }
 
 export function NewCardModal({ isOpen, onClose, onCreate }: NewCardModalProps) {
-  const [cardData, setCardData] = useState({
+  const [cardData, setCardData] = useState<CardInput>({
     type: 'task',
     title: '',
     description: '',
     priority: 'medium',
-    labels: [] as string[],
+    labels: [],
     estimate: 0
   });
 

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -1,0 +1,24 @@
+export interface NodeConfig {
+  name?: string;
+  source?: string;
+  query?: string;
+  transformType?: string;
+  code?: string;
+  destinationType?: string;
+  tableName?: string;
+  writeMode?: string;
+}
+
+export interface PipelineNodeData {
+  id: string;
+  type: 'source' | 'transform' | 'destination';
+  name: string;
+  config: NodeConfig;
+  position: { x: number; y: number };
+}
+
+export interface Connection {
+  from: string;
+  to: string;
+}
+


### PR DESCRIPTION
## Summary
- replace loosely typed props with specific interfaces for API, database, and resource creation modals
- introduce `NotebookData` and `ExecutionResult` types to clarify notebook and interpreter data flow
- add central pipeline types and typed query results to eliminate `any` usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install @eslint/js eslint-plugin-react-hooks eslint-plugin-react-refresh typescript-eslint --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e35040efc8322a1ce1f75d0f7e211