### PR TITLE
refactor: remove unused variables

### DIFF
--- a/src/components/JobsSection.tsx
+++ b/src/components/JobsSection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Plus, Search, Clock, Play, Pause, RotateCcw, AlertCircle, Calendar, GitBranch, Settings, ChevronRight, X } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Search, Clock, Play, Pause, RotateCcw, AlertCircle, GitBranch, Settings, X } from 'lucide-react';
 
 interface Job {
   id: number;
@@ -72,15 +72,6 @@ export function JobsSection() {
       }
       return job;
     }));
-  };
-
-  const handleCreateJob = (newJob: Omit<Job, 'id'>) => {
-    const job: Job = {
-      ...newJob,
-      id: Math.max(...jobs.map(j => j.id)) + 1,
-    };
-    setJobs([...jobs, job]);
-    setIsNewJobModalOpen(false);
   };
 
   const filteredJobs = jobs.filter(job =>

--- a/src/components/ModelsSection.tsx
+++ b/src/components/ModelsSection.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Plus, Search, Brain, Sparkles, GitBranch, History, Play, Settings, Database, ChevronRight, BarChart2, AlertCircle, Clock } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Search, Brain, Sparkles, GitBranch, History, Play, Settings } from 'lucide-react';
 import { NewModelModal, NewModelData } from './models/NewModelModal';
 import { ModelTrainingView } from './models/ModelTrainingView';
 import { AutoMLView } from './models/AutoMLView';
@@ -22,7 +22,6 @@ interface Model {
 
 export function ModelsSection() {
   const [activeView, setActiveView] = useState<'list' | 'train' | 'automl' | 'deploy'>('list');
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [isNewModelModalOpen, setIsNewModelModalOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 

--- a/src/components/notebook/CodeCell.tsx
+++ b/src/components/notebook/CodeCell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Code2 } from 'lucide-react';
 import { CodeInterpreter, ExecutionResult } from './CodeInterpreter';
 
@@ -23,7 +23,7 @@ export function CodeCell({ id, language, initialCode = '', onChange }: CodeCellP
   };
 
   return (
-    <div className="space-y-2">
+    <div id={id} className="space-y-2">
       {/* Code Editor */}
       <div className="relative">
         <div className="absolute left-4 top-4">

--- a/src/components/notebook/CodeInterpreter.tsx
+++ b/src/components/notebook/CodeInterpreter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Play, Loader2, XCircle } from 'lucide-react';
 
 export type ExecutionResult =


### PR DESCRIPTION
## Summary
- drop unused imports and state from Jobs and Models sections
- wire up `id` prop and tidy imports in notebook code cell/interpreter

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: existing TypeScript errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_688e388d37708322be66ae928f409b8e