### PR TITLE
chore: remove unused variables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Sidebar } from './components/Sidebar';
 import { Workspace } from './components/Workspace';
 import { DataSection } from './components/DataSection';

--- a/src/components/DashboardsSection.tsx
+++ b/src/components/DashboardsSection.tsx
@@ -96,7 +96,7 @@ export function DashboardsSection() {
       </div>
 
       {/* Main Dashboard */}
-      <AnalyticsDashboard dateRange={dateRange} />
+      <AnalyticsDashboard />
     </div>
   );
 }

--- a/src/components/dashboards/AnalyticsDashboard.tsx
+++ b/src/components/dashboards/AnalyticsDashboard.tsx
@@ -1,11 +1,7 @@
-import React from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, BarChart, Bar } from 'recharts';
 
-interface AnalyticsDashboardProps {
-  dateRange: string;
-}
-
-export function AnalyticsDashboard({ dateRange }: AnalyticsDashboardProps) {
+// TODO: Accept date range to filter dashboard data
+export function AnalyticsDashboard() {
   // Sample data - in a real app, this would come from your API
   const userActivityData = [
     { date: '2024-03-10', users: 2400, sessions: 4000 },
@@ -69,7 +65,7 @@ export function AnalyticsDashboard({ dateRange }: AnalyticsDashboardProps) {
                   paddingAngle={5}
                   dataKey="value"
                 >
-                  {trafficSourcesData.map((entry, index) => (
+                  {trafficSourcesData.map((_, index) => (
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>

--- a/src/components/models/ModelTrainingView.tsx
+++ b/src/components/models/ModelTrainingView.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { ArrowLeft, Brain, Play, Settings, Save, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { ArrowLeft, Brain, Play, ChevronRight } from 'lucide-react';
 
 interface ModelTrainingViewProps {
   onBack: () => void;
@@ -7,7 +7,8 @@ interface ModelTrainingViewProps {
 
 export function ModelTrainingView({ onBack }: ModelTrainingViewProps) {
   const [selectedAlgorithm, setSelectedAlgorithm] = useState('');
-  const [hyperparameters, setHyperparameters] = useState({});
+  // TODO: Add hyperparameter state management when configuration is implemented
+  // const [hyperparameters, setHyperparameters] = useState({});
   const [isTraining, setIsTraining] = useState(false);
 
   const algorithms = [


### PR DESCRIPTION
## Summary
- remove unused imports from App and dashboards
- drop unused parameters in AnalyticsDashboard and adjust usage
- tidy model training view and comment planned state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npx tsc -p tsconfig.app.json` (fails: TS2322, TS6133, etc.)

------
https://chatgpt.com/codex/tasks/task_e_688e40a2f49083229fcb1568609692d8